### PR TITLE
Add preprocessed command restriction

### DIFF
--- a/gary/app/Main.hs
+++ b/gary/app/Main.hs
@@ -108,7 +108,19 @@ main = do
           text <-
             case text' of
               Nothing -> liftIO exitSuccess
-              Just v -> return $ Text.pack v
+              Just v -> do
+                let inputText = Text.pack v
+                let restrictedCommands = ["rm -rf", "sudo rm", "mkfs", "dd if=", "cfdisk", "format"] :: [Text]
+                if any (\restricted -> Text.isInfixOf restricted inputText) restrictedCommands
+                  then do
+                    liftIO $ putStrLn $ red "Warning: This command is in the restricted list!"
+                    confirm <- getInputLine "Execute this command? (y/n): "
+                    case confirm of
+                      Just "y" -> return inputText
+                      _ -> do
+                        liftIO $ putStrLn $ red "Command cancelled."
+                        return "" -- Return empty input to skip processing
+                  else return inputText
           return [User{ content = [ Text{ text } ], name = Nothing }]
         _ -> do
           forM outstandingCalls $ \call -> do


### PR DESCRIPTION
Having an explicit list of commands to warn the user from dangerous input beforehand may save some tokens from being consumed by the api call unnecessarily. Any commands not explicitly filtered out will still make a call to open ai to determine if an action is considered unsafe and will consume tokens.